### PR TITLE
Fix argument on call `Image.frombytes`

### DIFF
--- a/PILasOPENCV.py
+++ b/PILasOPENCV.py
@@ -860,7 +860,7 @@ class Image(object):
         return colors
 
     def getdata(self):
-        flattened = self._instance.reshape((x*y, 3))
+        flattened = self._instance.reshape((self.size[0]*self.size[1], 3))
         return flattened
 
     def getextrema(self):

--- a/PILasOPENCV.py
+++ b/PILasOPENCV.py
@@ -2245,7 +2245,7 @@ def frombytes(mode, size, data, decoder_name="raw", *args):
         args = mode
 
     im = new(mode, size)
-    im.frombytes(data, decoder_name, args)
+    im.frombytes(mode, size, data, decoder_name, args)
     return im
 
 def fromstring(mode, size, data, decoder_name="raw", *args):

--- a/tests/test_frombytes.py
+++ b/tests/test_frombytes.py
@@ -1,0 +1,10 @@
+import unittest
+
+import PILasOPENCV as Image
+
+
+class TestImageFromBytes(unittest.TestCase):
+    def test_frombytes(self):
+        im1 = Image.open("lena.jpg")
+        im2 = Image.frombytes(im1.mode, im1.size, im1.getdata())
+        self.assertEqual(im1.getdata().tolist(), im2.getdata().tolist())


### PR DESCRIPTION
- Fix use `Image.frombytes` or `Image.frombuffer` raised `ValueError('Your mode name is incorrect.')`
- Add test case for `Image.frombytes`
- Implement `Image.getdata` for test case